### PR TITLE
Update FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,2 @@
-custom: https://numfocus.salsalabs.org/donate-to-sunpy/index.html
+github: numfocus
+custom: https://numfocus.org/donate-to-sunpy


### PR DESCRIPTION
add NumFOCUS github sponsors button (recurring donations only)

This feature launched today at GitHub Universe!

Also updated the custom link to point to the form located at numfocus.org, in case it provides more peace of mind for potential donors.

cc @Cadair