### PR TITLE
Update SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,44 +2,22 @@
 
 ## Documentation
 
-We strive to provide a rich and comprehensive set of documentation for all packages under the sunpy project.
-For sunpy, the [sunpy documentation] includes [examples] and an API layout that you can access through the [code reference].
-All packages under the sunpy project, they will have their own hosted documentation you can browse.
-Many should be found under the "Documentation" dropdown above.
+We strive to provide a rich and comprehensive set of documentation for all packages under the SunPy project.
+For sunpy core, the [sunpy documentation] includes [examples] and an API layout that you can access through the [code reference].
+All packages under the SunPy project have their own documentation, that can be found by clicking on the "Documentation" dropdown above.
 
-## Community
+## Asking questions
 
-You can stay up to date on the development of sunpy and interact with the community with these helpful resources:
+The recommended way to ask questions or get help with any of the packages under the SunPy project is the [OpenAstronomy discourse].
+Any questions you can be asked in the "Ask Questions" category.
 
-- Read and subscribe to [the sunpy blog].
-- Subscribe to the [sunpy mailing list].
-- Join us on github and add a feature request or bug report to our [issue list].
-- Chat with fellow sunpy users or developers on our [element.io channel].
-- Join us at one of our weekly meetings. Check out [our calendar] to find the next one.
+If you have a quick or shorter question, we also have a [element.io channel] for chatting, and you will find many sunpy users and developers within the channel.
+Please do stop by and say hello!
+You can login with any element.io account by typing in your full username, e.g., `@cadair:matrix.org`.
 
-Anyone can and is encouraged to get involved and we look forward to meeting you!
-Please be aware that we have a [Code of Conduct], that sets out how everyone should and will behave with each other.
-
-## Mailing List
-
-sunpy has two mailing lists; a [general mailing list] for general issues and a [developer mailing list].
-If you have a general question about how sunpy works please use the general mailing list and it is another way to get help with doing solar physics with Python.
-If, on the other hand you have a question about the inner workings of sunpy, how sunpy is organized or have a question about developing some new feature please use the developer mailing list.
-
-## Live Chat
-
-We have a [element.io channel] and you will find many sunpy users and developers within the channel.
-Please stop by and say hello.
-You can login with any element.io account by typing in your full username, i.e. `@cadair:matrix.org`.
 
 [sunpy documentation]: https://docs.sunpy.org/en/stable/
 [code reference]: https://docs.sunpy.org/en/stable/code_ref/index.html
 [examples]: https://docs.sunpy.org/en/stable/generated/gallery/index.html
-[the sunpy blog]: https://sunpy.org/blog.html
-[sunpy mailing list]: https://groups.google.com/forum/#!forum/sunpy
-[issue list]: https://github.com/sunpy/sunpy/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+First+Issue%22+sort%3Aupdated-desc
+[OpenAstronomy discourse]: https://community.openastronomy.org/c/ask-questions/15
 [element.io channel]: https://openastronomy.element.io/#/room/#sunpy:openastronomy.org
-[our calendar]: https://calendar.google.com/calendar/embed?src=g9c9eakg98b5cbogd7m5ta6h8s@group.calendar.google.com&pli=1
-[code of conduct]: https://docs.sunpy.org/en/latest/code_of_conduct.html
-[general mailing list]: https://groups.google.com/g/sunpy
-[developer mailing list]: https://groups.google.com/forum/#!forum/sunpy-dev


### PR DESCRIPTION
xref https://github.com/sunpy/sunpy.org/issues/277

I have made some large cuts to things I don't think involve "getting help", to make the page more streamlined. Perhaps the community stuff should move elsewhere? I think the following bits are not well used and outdated now though:

- Mailing lists (replaced by discourse)
- Calendar (I don't think anyone uses this?)