### PR TITLE
Restore link to issue tracker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,4 +51,5 @@ Note: This text was originally written by [Adrienne Lowe](https://github.com/adr
 [chat room]: https://app.element.io/#/room/#sunpy:openastronomy.org
 [mailing list]: https://groups.google.com/forum/#!forum/sunpy
 [discourse]: https://community.openastronomy.org/
+[issue tracker]: https://github.com/sunpy/sunpy/issues
 [Newcomers Guide]: https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html


### PR DESCRIPTION
## PR Description

I noticed that the link to the issue tracker in [the contributing guide](https://sunpy.org/contribute/#reporting-issues) is not actually linking. This PR restores the link as it was before #23.

I didn't open an issue first as I assumed this is small enough to not need one, but let me know if one is required.