### PR TITLE
Adopt NumFOCUS Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,46 +7,36 @@ It is through these differences that our community experiences success and conti
 We expect everyone in our community to follow these guidelines when interacting with others both inside and outside of our community.
 Our goal is to keep ours a positive, inclusive, successful, and growing community.
 
-A member of SunPy is:
+Since XXX, SunPy has adopted the NumFOCUS Code of Conduct, which is summarized below.
+For the previous version of the SunP Code of Conduct, see [here](https://sunpy.org/coc_old).
 
-## Open
+## The Short Version
 
-Members of the community are open to collaboration, whether on patches, reporting issues, asking for help or otherwise.
-We welcome those interested in joining the community, and realise that including people with a variety of opinions and backgrounds will only serve to enrich our community.
+Be kind to others.
+Do not insult or put down others.
+Behave professionally.
+Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for SunPy.
 
-We are accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference, ensuring that all participants are heard and feel confident that they can freely express their opinions.
+SunPy is dedicated to providing a harassment-free community for everyone, regardless of gender, sexual orientation, gender identity and expression, disability, physical appearance, body size, race, or religion.
+We do not tolerate harassment of community members in any form.
 
-## Considerate
+All communication should be appropriate for a professional audience including people of many different backgrounds.
+Sexual language and imagery is not appropriate.
 
-Members of the community are considerate of their peers -- other developers, users, etc.
-We are thoughtful when addressing the efforts of others, keeping in mind that often the labour was completed simply for the good of the community.
-We are attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
+Thank you for helping make this a welcoming, friendly community for all.
 
-We recognize the work made by everyone and ensure the proper acknowledgement/citation of original authors at all times.
-As authors, we pledge to be explicit about how we want our own work to be cited or acknowledged.
+## The Long Version
 
-## Respectful
+You can find the long version of the Code of Conduct on the [NumFOCUS website](https://numfocus.org/code-of-conduct).
 
-Members of the community are respectful.
-We are respectful of others, their positions, their skills, their commitments, and their efforts.
-We are respectful of the volunteer and professional efforts within the community.
-We are respectful of the processes set forth in the community, and we work within them (paying particular attention to those new to the community).
+## How To Report
 
-When we disagree, we are courteous in raising our issues.
-We provide a harassment- and bullying-free environment, regardless of sex, sexual orientation, gender identity, disability, physical appearance, body size, race, nationality, ethnicity, and religion.
-In particular, sexual language and imagery, sexist, racist, or otherwise exclusionary jokes are not appropriate.
-We will treat those outside our community with the same respect as people within our community.
+If you feel that the Code of Conduct has been violated, you can submit a report via the [NumFOCUS Code of Conduct Reporting Form](https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org).
 
-Overall, we are good to each other and apply this code of conduct to all community situations online and offline, including mailing lists, forums, social media, conferences, meetings, associated social events, and one-to-one interactions.
+### Who Will Receive Your Report
 
-We pledge to help the entire community follow the code of conduct, and to not remain silent when we see violations of the code of conduct.
-We will take action when members of our community violate this code such as contacting <confidential@sunpy.org> (all emails sent to this address will be treated with the strictest confidence) or talking privately with the person.
+Your report will be received and handled by NumFOCUS Code of Conduct Working Group; trained, and experienced contributors with diverse backgrounds.
+The group is making decisions independently from SunPy, PyData, NumFOCUS, or any other organization.
 
-Parts of this code of conduct have been adapted from the [astropy](https://www.astropy.org/code_of_conduct.html) and the [Python Software Foundation](https://www.python.org/psf/conduct/) codes of conduct.
-
----
-
-## License
-
-The SunPy Community Code of Conduct is licensed under a Creative Commons Attribution 4.0 International License.
-We encourage other communities related to ours to use or adapt this code as they see fit.
+The Working Group will work with the SunPy Steering Committee to resolve an incident.
+The NumFOCUS Code of Conduct Working group will review the incident, and provide recommendations on how to handle this or what consequences or sanction might be appropriate.


### PR DESCRIPTION
Update wording for adopting NumFOCUS coc, see https://github.com/sunpy/sunpy.org/pull/491 for the website side